### PR TITLE
Disable JIT by default to prevent error with Python 3.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,24 +101,24 @@ l = ssim(x, y, kernel=kernel, channel_avg=False)
 
 Most functional components of `piqa` support  PyTorch's JIT, *i.e.* [TorchScript](https://pytorch.org/docs/stable/jit.html), which is a way to create serializable and optimizable functions from PyTorch code.
 
-By default, jitting is enabled for those components. To disable it, the `PIQA_JIT` environment variable has to be set to `0`. To do so temporarily,
+By default, jitting is disabled for those components. To enable it, the `PIQA_JIT` environment variable has to be set to `1`. To do so temporarily,
 
 * UNIX-like `bash`
 
 ```bash
-export PIQA_JIT=0
+export PIQA_JIT=1
 ```
 
 * Windows `cmd`
 
 ```cmd
-set PIQA_JIT=0
+set PIQA_JIT=1
 ```
 
 * Microsoft `PowerShell`
 
 ```powershell
-$env:PIQA_JIT=0
+$env:PIQA_JIT=1
 ```
 
 ### Assert

--- a/docs.sh
+++ b/docs.sh
@@ -5,7 +5,7 @@ source ~/piqa/bin/activate
 git checkout master
 
 # Generate HTML
-PIQA_JIT=0 pdoc piqa --html --force \
+pdoc piqa --html --force \
     --config "git_link_template='https://github.com/francois-rozet/piqa/blob/{commit}/{path}#L{start_line}-L{end_line}'" \
     --config "show_inherited_members=True" \
     --config "latex_math=True"

--- a/piqa/__init__.py
+++ b/piqa/__init__.py
@@ -5,7 +5,7 @@ which implements the functions and/or classes related to a
 specific image quality assessement metric.
 """
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 from .tv import TV
 from .psnr import PSNR

--- a/piqa/utils/__init__.py
+++ b/piqa/utils/__init__.py
@@ -7,10 +7,10 @@ import torch
 from typing import List, Tuple
 
 
-if os.getenv('PIQA_JIT') == '0':
-    _jit = lambda f: f
-else:
+if os.getenv('PIQA_JIT') == '1':
     _jit = torch.jit.script
+else:
+    _jit = lambda f: f
 
 
 def _debug(mode: bool = __debug__) -> bool:


### PR DESCRIPTION
Closes https://github.com/francois-rozet/piqa/issues/6