### PR TITLE
RuntimeError with non-contiguous tensors in PSNR

### DIFF
--- a/piqa/psnr.py
+++ b/piqa/psnr.py
@@ -36,7 +36,7 @@ def mse(x: Tensor, y: Tensor) -> Tensor:
         torch.Size([5])
     """
 
-    return ((x - y) ** 2).view(x.size(0), -1).mean(dim=-1)
+    return ((x - y) ** 2).reshape(x.size(0), -1).mean(dim=-1)
 
 
 @_jit


### PR DESCRIPTION
I got the following error by using PSNR:
 "view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead."

After some research a way to solve this problem is just to replace "view()" by "reshape()" or use contiguous() before view
https://github.com/cezannec/capsule_net_pytorch/issues/4

Note that using reshape will not kill the performance since if it can, it will uses a view of the input:
https://pytorch.org/docs/master/generated/torch.reshape.html#torch.reshape