### PR TITLE
LPIPS with Alex net returns Nan

### DIFF
--- a/piqa/lpips.py
+++ b/piqa/lpips.py
@@ -28,7 +28,7 @@ from .utils.functional import l2_norm
 ORIGIN: str = 'https://github.com/richzhang/PerceptualSimilarity'
 SHIFT: Tensor = torch.tensor([0.485, 0.456, 0.406])
 SCALE: Tensor = torch.tensor([0.229, 0.224, 0.225])
-
+EPS: float = 1e-10
 
 def get_weights(
     network: str = 'alex',
@@ -210,8 +210,8 @@ class LPIPS(nn.Module):
         residuals = []
 
         for lin, fx, fy in zip(self.lins, self.net(input), self.net(target)):
-            fx = fx / l2_norm(fx, dims=[1], keepdim=True)
-            fy = fy / l2_norm(fy, dims=[1], keepdim=True)
+            fx = fx / (l2_norm(fx, dims=[1], keepdim=True) + EPS)
+            fy = fy / (l2_norm(fy, dims=[1], keepdim=True) + EPS)
 
             mse = ((fx - fy) ** 2).mean(dim=(-1, -2), keepdim=True)
             residuals.append(lin(mse).flatten())

--- a/piqa/lpips.py
+++ b/piqa/lpips.py
@@ -11,8 +11,6 @@ References:
     .. [Deng2009] ImageNet: A large-scale hierarchical image database (Deng et al, 2009)
 """
 
-import inspect
-import os
 import torch
 import torch.nn as nn
 import torchvision.models as models
@@ -28,7 +26,7 @@ from .utils.functional import l2_norm
 ORIGIN: str = 'https://github.com/richzhang/PerceptualSimilarity'
 SHIFT: Tensor = torch.tensor([0.485, 0.456, 0.406])
 SCALE: Tensor = torch.tensor([0.229, 0.224, 0.225])
-EPS: float = 1e-10
+
 
 def get_weights(
     network: str = 'alex',
@@ -119,6 +117,7 @@ class LPIPS(nn.Module):
         network: Specifies the perceptual network :math:`\mathcal{F}` to use:
             `'alex'` | `'squeeze'` | `'vgg'`.
         scaling: Whether the input and target need to be scaled w.r.t. [Deng2009]_.
+        epsilon: A numerical stability term.
         dropout: Whether dropout is used or not.
         pretrained: Whether the official weights :math:`w_l` are used or not.
         eval: Whether to initialize the object in evaluation mode or not.
@@ -144,6 +143,7 @@ class LPIPS(nn.Module):
         self,
         network: str = 'alex',
         scaling: bool = True,
+        epsilon: float = 1e-10,
         dropout: bool = False,
         pretrained: bool = True,
         eval: bool = True,
@@ -155,6 +155,7 @@ class LPIPS(nn.Module):
         self.scaling = scaling
         self.register_buffer('shift', SHIFT.reshape(1, -1, 1, 1))
         self.register_buffer('scale', SCALE.reshape(1, -1, 1, 1))
+        self.epsilon = epsilon
 
         # Perception layers
         if network == 'alex':  # AlexNet
@@ -210,8 +211,8 @@ class LPIPS(nn.Module):
         residuals = []
 
         for lin, fx, fy in zip(self.lins, self.net(input), self.net(target)):
-            fx = fx / (l2_norm(fx, dims=[1], keepdim=True) + EPS)
-            fy = fy / (l2_norm(fy, dims=[1], keepdim=True) + EPS)
+            fx = fx / (l2_norm(fx, dims=[1], keepdim=True) + self.epsilon)
+            fy = fy / (l2_norm(fy, dims=[1], keepdim=True) + self.epsilon)
 
             mse = ((fx - fy) ** 2).mean(dim=(-1, -2), keepdim=True)
             residuals.append(lin(mse).flatten())


### PR DESCRIPTION
LPIPS with Alex net returns Nan

The issue is caused by some of the feature layers might zero and it leads to Nan during their normalization. Original implementation uses small epsilon to avoid the issue https://github.com/richzhang/PerceptualSimilarity/blob/31bc1271ae6f13b7e281b9959ac24a5e8f2ed522/lpips/__init__.py#L13

I've verified that results, after changes, are the same as in the original lib (PerceptualSimilarity).

Here are pictures that lead to Nan measure (I hope GitHub attaches images without additional compressing if so, I'll send them in zip):
![3132](https://user-images.githubusercontent.com/4352611/189436853-913f26ed-ef10-4dbe-b7bb-78887266ff4f.jpg)
![2908](https://user-images.githubusercontent.com/4352611/189436867-44307b97-c5bb-489b-8264-efae4bdcd1d3.jpg)

